### PR TITLE
Check rel type before checking properties

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -753,7 +753,8 @@ class LLMGraphTransformer:
             for rel in parsed_json:
                 # Check if mandatory properties are there
                 if (
-                    not rel.get("head")
+                    not isinstance(rel, dict)
+                    or not rel.get("head")
                     or not rel.get("tail")
                     or not rel.get("relation")
                 ):


### PR DESCRIPTION
Minor change, but lazy evaluation of the type before checking whether the properties are there saves me a lot of unnecessary exceptions.