### PR TITLE
Specify `method` for `with_structured_output`

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -825,7 +825,11 @@ class LLMGraphTransformer:
                 relationship_properties,
                 self._relationship_type,
             )
-            structured_llm = llm.with_structured_output(schema, method=method, include_raw=True)
+            structured_llm = llm.with_structured_output(
+                schema, 
+                method=method,
+                include_raw=True
+            )
             prompt = prompt or get_default_prompt(additional_instructions)
             self.chain = prompt | structured_llm
 

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -771,7 +771,7 @@ class LLMGraphTransformer:
         relationship_properties: Union[bool, List[str]] = False,
         ignore_tool_usage: bool = False,
         additional_instructions: str = "",
-        method: str = "json_schema"
+        method: str = "json_schema",
     ) -> None:
         # Validate and check allowed relationships input
         self._relationship_type = validate_and_get_relationship_type(
@@ -826,9 +826,7 @@ class LLMGraphTransformer:
                 self._relationship_type,
             )
             structured_llm = llm.with_structured_output(
-                schema, 
-                method=method,
-                include_raw=True
+                schema, method=method, include_raw=True
             )
             prompt = prompt or get_default_prompt(additional_instructions)
             self.chain = prompt | structured_llm

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -771,6 +771,7 @@ class LLMGraphTransformer:
         relationship_properties: Union[bool, List[str]] = False,
         ignore_tool_usage: bool = False,
         additional_instructions: str = "",
+        method: str = "json_schema"
     ) -> None:
         # Validate and check allowed relationships input
         self._relationship_type = validate_and_get_relationship_type(
@@ -784,7 +785,7 @@ class LLMGraphTransformer:
         # Check if the LLM really supports structured output
         if self._function_call:
             try:
-                llm.with_structured_output(_Graph)
+                llm.with_structured_output(_Graph, method=method)
             except NotImplementedError:
                 self._function_call = False
         if not self._function_call:
@@ -824,7 +825,7 @@ class LLMGraphTransformer:
                 relationship_properties,
                 self._relationship_type,
             )
-            structured_llm = llm.with_structured_output(schema, include_raw=True)
+            structured_llm = llm.with_structured_output(schema, method=method, include_raw=True)
             prompt = prompt or get_default_prompt(additional_instructions)
             self.chain = prompt | structured_llm
 

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -744,6 +744,8 @@ class LLMGraphTransformer:
           function calling capabilities to handle structured output. Defaults to False.
         additional_instructions (str): Allows you to add additional instructions
           to the prompt without having to change the whole prompt.
+        structured_output_kwargs (Optional[dict], optional): The dict of keyword
+          arguments to pass to `with_structured_output`
 
     Example:
         .. code-block:: python
@@ -771,7 +773,7 @@ class LLMGraphTransformer:
         relationship_properties: Union[bool, List[str]] = False,
         ignore_tool_usage: bool = False,
         additional_instructions: str = "",
-        method: str = "json_schema",
+        structured_output_kwargs: Optional[dict] = None,
     ) -> None:
         # Validate and check allowed relationships input
         self._relationship_type = validate_and_get_relationship_type(
@@ -782,10 +784,11 @@ class LLMGraphTransformer:
         self.allowed_relationships = allowed_relationships
         self.strict_mode = strict_mode
         self._function_call = not ignore_tool_usage
+        structured_output_kwargs = structured_output_kwargs or {}
         # Check if the LLM really supports structured output
         if self._function_call:
             try:
-                llm.with_structured_output(_Graph, method=method)
+                llm.with_structured_output(_Graph, **structured_output_kwargs)
             except NotImplementedError:
                 self._function_call = False
         if not self._function_call:
@@ -826,7 +829,7 @@ class LLMGraphTransformer:
                 self._relationship_type,
             )
             structured_llm = llm.with_structured_output(
-                schema, method=method, include_raw=True
+                schema, include_raw=True, **structured_output_kwargs
             )
             prompt = prompt or get_default_prompt(additional_instructions)
             self.chain = prompt | structured_llm


### PR DESCRIPTION
The default option of "function_calling" for Ollama was leading to errors.  Defaulting to "json_schema" (as ChatOpenAI already does) results in success for Ollama.  Expose the `method` argument to the user for finer-grained control if needed.

Fixes #38.

I'm not sure if this is the right approach but figured it would be a good starting point for a discussion.  The script below used to trigger the parsing error mentioned in the issue.  With the fix here, Ollama is able to produce Nodes and Relationships:

```python
from langchain_ollama import ChatOllama
from langchain_experimental.graph_transformers import LLMGraphTransformer
from langchain_core.documents import Document

llm = ChatOllama(model="llama3.1", num_ctx=4096)
doc = Document(
    "The lazy dog watched as the red ball rolled.  Bob the clown scared the missles."
)

allowed_nodes = ["Animal", "Person", "Object"]

doc_transformer = LLMGraphTransformer(
    llm=llm, allowed_nodes=allowed_nodes
)

graph_doc = doc_transformer.convert_to_graph_documents([doc])
print(graph_doc)
```
Output:
```console
GraphDocument(nodes=[Node(id='Lazy Dog', type='Person', properties={}), Node(id='Red Ball', type='Object', properties={}), Node(id='Bob The Clown', type='Person', properties={})], relationships=[Relationship(source=Node(id='Lazy Dog', type='Person', properties={}), target=Node(id='Red Ball', type='Object', properties={}), type='WATCHED', properties={}), Relationship(source=Node(id='Bob The Clown', type='Person', properties={}), target=Node(id='Missles', type='Object', properties={}), type='SCARED', properties={})], source=Document(metadata={}, page_content='The lazy dog watched as the red ball rolled.  Bob the clown scared the missles.'))]
``` 