### PR TITLE
Fix case_insensitive_matching_strategy-with special characters

### DIFF
--- a/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
+++ b/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
@@ -42,11 +42,11 @@ def case_insensitive_matching_strategy(
         for anonymized, original in deanonymizer_mapping[entity_type].items():
             # Use regular expressions for case-insensitive matching and replacing
             text = re.sub(
-                 pattern=re.escape(pattern=anonymized),
-                 repl=original,
-                 string=text,
-                 flags=re.IGNORECASE,
-             )
+                pattern=re.escape(pattern=anonymized),
+                repl=original,
+                string=text,
+                flags=re.IGNORECASE,
+                )
     return text
 
 

--- a/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
+++ b/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
@@ -46,7 +46,7 @@ def case_insensitive_matching_strategy(
                 repl=original,
                 string=text,
                 flags=re.IGNORECASE,
-                )
+            )
     return text
 
 

--- a/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
+++ b/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
@@ -41,10 +41,12 @@ def case_insensitive_matching_strategy(
     for entity_type in deanonymizer_mapping:
         for anonymized, original in deanonymizer_mapping[entity_type].items():
             # Use regular expressions for case-insensitive matching and replacing
-            text = re.sub(pattern=re.escape(pattern=anonymized),
-                          repl=original,
-                          string=text,
-                          flags=re.IGNORECASE)
+            text = re.sub(
+              pattern=re.escape(pattern=anonymized),
+             repl=original,
+             string=text,
+             flags=re.IGNORECASE,
+            )
     return text
 
 

--- a/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
+++ b/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
@@ -41,7 +41,10 @@ def case_insensitive_matching_strategy(
     for entity_type in deanonymizer_mapping:
         for anonymized, original in deanonymizer_mapping[entity_type].items():
             # Use regular expressions for case-insensitive matching and replacing
-            text = re.sub(anonymized, original, text, flags=re.IGNORECASE)
+            text = re.sub(pattern=re.escape(pattern=anonymized),
+                          repl=original,
+                          string=text,
+                          flags=re.IGNORECASE)
     return text
 
 

--- a/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
+++ b/libs/experimental/langchain_experimental/data_anonymizer/deanonymizer_matching_strategies.py
@@ -42,11 +42,11 @@ def case_insensitive_matching_strategy(
         for anonymized, original in deanonymizer_mapping[entity_type].items():
             # Use regular expressions for case-insensitive matching and replacing
             text = re.sub(
-              pattern=re.escape(pattern=anonymized),
-             repl=original,
-             string=text,
-             flags=re.IGNORECASE,
-            )
+                 pattern=re.escape(pattern=anonymized),
+                 repl=original,
+                 string=text,
+                 flags=re.IGNORECASE,
+             )
     return text
 
 


### PR DESCRIPTION
Hi guys,

There is a bug in **case_insensitive_matching_strategy**.

It use

`text = re.sub(anonymized, original, text, flags=re.IGNORECASE)`

to replace `anonymized` with `original` in `text`.

For phone numbers such as "+1-235-234-8740x164" starting with "+"

`text = re.sub(pattern='+1-235-234-8740x164', repl='XXX', string='XXX', flags=re.IGNORECASE)`

The first parameter `pattern` expect a string or a regular expressions string, if the string starts with "+", it will be recognized as a regular expressions and lead to an error.

In regular expressions "+" causes the resulting RE to match 1 or more repetitions of the preceding RE, but there is no characters before "+" in phone number.
-> re.error: nothing to repeat at position 0


How to reproduce:
```
anonymizer = PresidioReversibleAnonymizer()
anonymizer._deanonymizer_mapping.update(new_mapping={'PHONE_NUMBER': {'+1-235-234-8740x164': '12345678'}})
anonymizer.deanonymize(text_to_deanonymize='some text', deanonymizer_matching_strategy=case_insensitive_matching_strategy)
```

How to fix:
```
    for entity_type in deanonymizer_mapping:
        for anonymized, original in deanonymizer_mapping[entity_type].items():
            # Use regular expressions for case-insensitive matching and replacing
            text = re.sub(pattern=re.escape(pattern=anonymized),
                          repl=original,
                          string=text,
                          flags=re.IGNORECASE)
    return text
```