### PR TITLE
Avoid check fullpath of /bin/sh on nixos

### DIFF
--- a/libs/experimental/tests/unit_tests/test_bash.py
+++ b/libs/experimental/tests/unit_tests/test_bash.py
@@ -58,7 +58,7 @@ def test_incorrect_command_return_err_output() -> None:
     session = BashProcess(return_err_output=True)
     output = session.run(["invalid_command"])
     assert re.match(
-        r"^/bin/sh:.*invalid_command.*(?:not found|Permission denied).*$", output
+        r".*/bin/sh:.*invalid_command.*(?:not found|Permission denied).*$", output
     )
 
 


### PR DESCRIPTION
On NixOS, we got this result

```
/nix/store/00zrahbb32nzawrmv9sjxn36h7qk9vrs-bash-5.2p37/bin/sh: line 1: invalid_command: command not found
```

so the check failing 