### PR TITLE
Add Bodo engine to create_pandas_dataframe_agent

### DIFF
--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
@@ -168,7 +168,7 @@ def create_pandas_dataframe_agent(
     include_df_in_prompt: Optional[bool] = True,
     number_of_head_rows: int = 5,
     extra_tools: Sequence[BaseTool] = (),
-    engine: Literal["pandas", "modin"] = "pandas",
+    engine: Literal["pandas", "bodo", "modin"] = "pandas",
     allow_dangerous_code: bool = False,
     **kwargs: Any,
 ) -> AgentExecutor:
@@ -211,7 +211,7 @@ def create_pandas_dataframe_agent(
         number_of_head_rows: Number of initial rows to include in prompt if
             include_df_in_prompt is True.
         extra_tools: Additional tools to give to agent on top of a PythonAstREPLTool.
-        engine: One of "modin" or "pandas". Defaults to "pandas".
+        engine: One of "bodo" or "modin" or "pandas". Defaults to "pandas".
         allow_dangerous_code: bool, default False
             This agent relies on access to a python repl tool which can execute
             arbitrary code. This can be dangerous and requires a specially sandboxed
@@ -265,7 +265,8 @@ def create_pandas_dataframe_agent(
             import pandas as pd
         else:
             raise ValueError(
-                f"Unsupported engine {engine}. It must be one of 'modin' or 'pandas'."
+                f"Unsupported engine {engine}. "
+                "It must be one of 'bodo' or 'modin' or 'pandas'."
             )
     except ImportError as e:
         raise ImportError(

--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
@@ -256,7 +256,10 @@ def create_pandas_dataframe_agent(
             "https://python.langchain.com/docs/security/"
         )
     try:
-        if engine == "modin":
+        if engine == "bodo":
+            import bodo.pandas as bd
+            import pandas as pd
+        elif engine == "modin":
             import modin.pandas as pd
         elif engine == "pandas":
             import pandas as pd
@@ -275,6 +278,13 @@ def create_pandas_dataframe_agent(
     for _df in df if isinstance(df, list) else [df]:
         if not isinstance(_df, pd.DataFrame):
             raise ValueError(f"Expected pandas DataFrame, got {type(_df)}")
+
+    # Convert dataframes to Bodo DataFrames if engine is set to "bodo"
+    if engine == "bodo":
+        if isinstance(df, list):
+            df = [bd.from_pandas(d) if not isinstance(d, bd.DataFrame) else d for d in df]
+        else:
+            df = bd.from_pandas(df) if not isinstance(df, bd.DataFrame) else df
 
     if input_variables:
         kwargs = kwargs or {}

--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
@@ -282,7 +282,9 @@ def create_pandas_dataframe_agent(
     # Convert dataframes to Bodo DataFrames if engine is set to "bodo"
     if engine == "bodo":
         if isinstance(df, list):
-            df = [bd.from_pandas(d) if not isinstance(d, bd.DataFrame) else d for d in df]
+            df = [
+                bd.from_pandas(d) if not isinstance(d, bd.DataFrame) else d for d in df
+            ]
         else:
             df = bd.from_pandas(df) if not isinstance(df, bd.DataFrame) else df
 


### PR DESCRIPTION
Closes #60.

Bodo is a drop-in replacement for Pandas that accelerates and scales Pandas code using a compiler and HPC-based C++ backend. Bodo can accelerate Pandas code substantially (much faster than Modin):
https://www.bodo.ai/blog/python-data-processing-engine-comparison-with-nyc-taxi-trips-bodo-vs-spark-dask-ray

https://github.com/bodo-ai/Bodo
