### PR TITLE
[Semantic Chunking] Improvement : Inability to Determine the Breakpoint between s1 and s2

### DIFF
--- a/libs/experimental/langchain_experimental/text_splitter.py
+++ b/libs/experimental/langchain_experimental/text_splitter.py
@@ -168,7 +168,9 @@ class SemanticChunker(BaseDocumentTransformer):
 
         return cast(float, np.percentile(distances, y))
 
-    def _calculate_sentence_distances(self, single_sentences_list: List[str]) -> Tuple[List[float], List[dict]]:
+    def _calculate_sentence_distances(
+        self, single_sentences_list: List[str]
+    ) -> Tuple[List[float], List[dict]]:
         
         sentence_embeddings = self.embeddings.embed_documents(single_sentences_list)
         _sentences = [
@@ -181,12 +183,16 @@ class SemanticChunker(BaseDocumentTransformer):
             # Pre-Context (Clamping)
             pre_start = i - self.buffer_size + 1
             pre_indices = [max(0, j) for j in range(pre_start, i + 1)]
-            pre_mean = np.mean([_sentences[idx]["embedding"] for idx in pre_indices], axis=0)
+            pre_mean = np.mean(
+                [_sentences[idx]["embedding"] for idx in pre_indices], axis=0
+            )
 
             # Post-Context (Clamping)
             post_end = i + 1 + self.buffer_size
             post_indices = [min(len(_sentences) - 1, j) for j in range(i + 1, post_end)]
-            post_mean = np.mean([_sentences[idx]["embedding"] for idx in post_indices], axis=0)
+            post_mean = np.mean(
+                [_sentences[idx]["embedding"] for idx in post_indices], axis=0
+            )
 
             similarity = cosine_similarity([pre_mean], [post_mean])[0][0]
             _sentences[i]["distance_to_next"] = 1 - similarity

--- a/libs/experimental/langchain_experimental/text_splitter.py
+++ b/libs/experimental/langchain_experimental/text_splitter.py
@@ -54,34 +54,11 @@ def combine_sentences(sentences: List[dict], buffer_size: int = 1) -> List[dict]
 
 
 def calculate_cosine_distances(sentences: List[dict]) -> Tuple[List[float], List[dict]]:
-    """Calculate cosine distances between sentences.
-
-    Args:
-        sentences: List of sentences to calculate distances for.
-
-    Returns:
-        Tuple of distances and sentences.
-    """
     distances = []
+    # Use the distance_to_next value already calculated in _calculate_sentence_distances
     for i in range(len(sentences) - 1):
-        embedding_current = sentences[i]["combined_sentence_embedding"]
-        embedding_next = sentences[i + 1]["combined_sentence_embedding"]
-
-        # Calculate cosine similarity
-        similarity = cosine_similarity([embedding_current], [embedding_next])[0][0]
-
-        # Convert to cosine distance
-        distance = 1 - similarity
-
-        # Append cosine distance to the list
+        distance = sentences[i].get("distance_to_next", 0.0)
         distances.append(distance)
-
-        # Store distance in the dictionary
-        sentences[i]["distance_to_next"] = distance
-
-    # Optionally handle the last sentence
-    # sentences[-1]['distance_to_next'] = None  # or a default value
-
     return distances, sentences
 
 
@@ -191,22 +168,30 @@ class SemanticChunker(BaseDocumentTransformer):
 
         return cast(float, np.percentile(distances, y))
 
-    def _calculate_sentence_distances(
-        self, single_sentences_list: List[str]
-    ) -> Tuple[List[float], List[dict]]:
-        """Split text into multiple components."""
-
+    def _calculate_sentence_distances(self, single_sentences_list: List[str]) -> Tuple[List[float], List[dict]]:
+        
+        sentence_embeddings = self.embeddings.embed_documents(single_sentences_list)
         _sentences = [
-            {"sentence": x, "index": i} for i, x in enumerate(single_sentences_list)
+            {"sentence": x, "index": i, "embedding": sentence_embeddings[i]}
+            for i, x in enumerate(single_sentences_list)
         ]
-        sentences = combine_sentences(_sentences, self.buffer_size)
-        embeddings = self.embeddings.embed_documents(
-            [x["combined_sentence"] for x in sentences]
-        )
-        for i, sentence in enumerate(sentences):
-            sentence["combined_sentence_embedding"] = embeddings[i]
 
-        return calculate_cosine_distances(sentences)
+        # Compare non-overlapping windows at every boundary (between $i$ and $i+1$)
+        for i in range(len(_sentences) - 1):
+            # Pre-Context (Clamping)
+            pre_start = i - self.buffer_size + 1
+            pre_indices = [max(0, j) for j in range(pre_start, i + 1)]
+            pre_mean = np.mean([_sentences[idx]["embedding"] for idx in pre_indices], axis=0)
+
+            # Post-Context (Clamping)
+            post_end = i + 1 + self.buffer_size
+            post_indices = [min(len(_sentences) - 1, j) for j in range(i + 1, post_end)]
+            post_mean = np.mean([_sentences[idx]["embedding"] for idx in post_indices], axis=0)
+
+            similarity = cosine_similarity([pre_mean], [post_mean])[0][0]
+            _sentences[i]["distance_to_next"] = 1 - similarity
+
+        return calculate_cosine_distances(_sentences)
 
     def _get_single_sentences_list(self, text: str) -> List[str]:
         return re.split(self.sentence_split_regex, text)

--- a/libs/experimental/langchain_experimental/text_splitter.py
+++ b/libs/experimental/langchain_experimental/text_splitter.py
@@ -171,7 +171,6 @@ class SemanticChunker(BaseDocumentTransformer):
     def _calculate_sentence_distances(
         self, single_sentences_list: List[str]
     ) -> Tuple[List[float], List[dict]]:
-        
         sentence_embeddings = self.embeddings.embed_documents(single_sentences_list)
         _sentences = [
             {"sentence": x, "index": i, "embedding": sentence_embeddings[i]}

--- a/libs/experimental/langchain_experimental/text_splitter.py
+++ b/libs/experimental/langchain_experimental/text_splitter.py
@@ -182,17 +182,14 @@ class SemanticChunker(BaseDocumentTransformer):
             # Pre-Context (Clamping)
             pre_start = i - self.buffer_size + 1
             pre_indices = [max(0, j) for j in range(pre_start, i + 1)]
-            pre_mean = np.mean(
-                [_sentences[idx]["embedding"] for idx in pre_indices], axis=0
-            )
+            pre_embeddings = [_sentences[idx]["embedding"] for idx in pre_indices]
+            pre_mean = np.mean(cast(List[Any], pre_embeddings), axis=0)
 
             # Post-Context (Clamping)
             post_end = i + 1 + self.buffer_size
             post_indices = [min(len(_sentences) - 1, j) for j in range(i + 1, post_end)]
-            post_mean = np.mean(
-                [_sentences[idx]["embedding"] for idx in post_indices], axis=0
-            )
-
+            post_embeddings = [_sentences[idx]["embedding"] for idx in post_indices]
+            post_mean = np.mean(cast(List[Any], post_embeddings), axis=0)
             similarity = cosine_similarity([pre_mean], [post_mean])[0][0]
             _sentences[i]["distance_to_next"] = 1 - similarity
 


### PR DESCRIPTION
Using the SemanticChunker, I identified a structural issue in the combine_sentences logic that leads to a "Dead Zone" in boundary detection at the beginning of documents.


**Current Problem (As-is)**
In the current implementation of combine_sentences, the first sentence has a smaller context buffer compared to the middle ones. 
For example, with buffer_size=1:

- combine_sentence1: {s1, s2}
- combine_sentence2: {s1, s2, s3}

As shown in the attached diagram (As-is), combine_sentence1 is a strict subset of combine_sentence2. 
and the comparison between combine_sentence1 and combine_sentence2 serves as the basis for judging the breakpoint between s1 and s2.

and next_step :
- combine_sentence2: {s1, s2, s3}
- combine_sentence3: {s2, s3, s4}

In the next step, the algorithm compares combine_sentence2 and combine_sentence3 to evaluate the breakpoint between s3 and s4.

Under this repetitive logic, we cannot determine the breakpoint between s1 and s2.

<img width="905" height="202" alt="Image" src="https://github.com/user-attachments/assets/9c11b6cb-ee5c-4081-9b94-a2e746cb1337" />


The following is a concrete case where this behavior is observed.

If this direction aligns with the project's goals,
I would highly value your feedback and would be grateful if you could consider this direction


<img width="1823" height="397" alt="Image" src="https://github.com/user-attachments/assets/9fb637bf-8ac7-4302-8b67-65f2a929dd34" />

The description of the improved algorithm can be found at the link below (LangChain Forum).
(https://forum.langchain.com/t/inability-to-determine-the-breakpoint-between-s1-and-s2-due-to-current-windowing-logic/3148)

 the improved results after applying the proposed logic
<img width="1826" height="756" alt="image" src="https://github.com/user-attachments/assets/2bb20d98-23ef-411e-8a78-fe649938237c" />
